### PR TITLE
Drop ineffective cleanup commands

### DIFF
--- a/hu.irl.sysex-controls.yml
+++ b/hu.irl.sysex-controls.yml
@@ -14,16 +14,6 @@ finish-args:
   - --device=dri
   # MIDI
   - --socket=pulseaudio
-cleanup:
-  - /include
-  - /lib/pkgconfig
-  - /man
-  - /share/doc
-  - /share/gtk-doc
-  - /share/man
-  - /share/pkgconfig
-  - "*.la"
-  - "*.a"
 modules:
   - name: sysex-controls
     builddir: true


### PR DESCRIPTION
They are unnecessary because no files are affected by these commands.